### PR TITLE
Sidebar update

### DIFF
--- a/.changeset/fuzzy-tomatoes-tickle.md
+++ b/.changeset/fuzzy-tomatoes-tickle.md
@@ -1,0 +1,5 @@
+---
+"vocs": patch
+---
+
+Fixed collapsible nav titles now redirect to their first sub-nav option and highlight when selected.

--- a/src/app/components/Sidebar.css.ts
+++ b/src/app/components/Sidebar.css.ts
@@ -195,6 +195,17 @@ export const sectionTitle = style(
   'sectionTitle',
 )
 
+export const sectionTitleActive = style(
+  {
+    color: primitiveColorVars.textAccent,
+    fontSize: fontSizeVars['14'],
+    fontWeight: fontWeightVars.semibold,
+    letterSpacing: '0.25px',
+    width: '100%',
+  },
+  'sectionTitleActive',
+)
+
 export const sectionTitleLink = style(
   {
     selectors: {

--- a/src/app/components/Sidebar.tsx
+++ b/src/app/components/Sidebar.tsx
@@ -21,6 +21,17 @@ import { RouterLink } from './RouterLink.js'
 import * as styles from './Sidebar.css.js'
 import { ChevronRight } from './icons/ChevronRight.js'
 
+function checkSectionTitleActive(items: any[], pathname: string) {
+  const result = Boolean(items.find((item) => {
+    if (item.link) {
+      return item.link === pathname;
+    };
+    return false;
+  }));
+
+  return !!result;
+}
+
 export function Sidebar(props: {
   className?: string
   onClickItem?: MouseEventHandler<HTMLAnchorElement>
@@ -141,7 +152,7 @@ function SidebarItem(props: {
     (event: KeyboardEvent | MouseEvent) => {
       if ('key' in event && event.key !== 'Enter') return
       if (item.link) return
-      setCollapsed((x) => !x)
+      setCollapsed((x) => !x)    
     },
     [item.link],
   )
@@ -206,8 +217,16 @@ function SidebarItem(props: {
                   {item.text}
                 </RouterLink>
               ) : (
-                <div className={clsx(depth === 0 ? styles.sectionTitle : styles.item)}>
-                  {item.text}
+                <div className={clsx(depth === 0 ? (item.items && checkSectionTitleActive(item.items, pathname) ? styles.sectionTitleActive : styles.sectionTitle) : styles.item)}>
+                  {item.items && !checkSectionTitleActive(item.items, pathname) && collapsed ? (
+                    <RouterLink
+                      data-active={false}
+                      onClick={onClick}
+                      to={item.items[0].link!}
+                    >
+                      {item.text}
+                    </RouterLink>
+                  ) : item.text}
                 </div>
               ))}
 

--- a/src/app/components/Sidebar.tsx
+++ b/src/app/components/Sidebar.tsx
@@ -22,14 +22,16 @@ import * as styles from './Sidebar.css.js'
 import { ChevronRight } from './icons/ChevronRight.js'
 
 function checkSectionTitleActive(items: any[], pathname: string) {
-  const result = Boolean(items.find((item) => {
-    if (item.link) {
-      return item.link === pathname;
-    };
-    return false;
-  }));
+  const result = Boolean(
+    items.find((item) => {
+      if (item.link) {
+        return item.link === pathname
+      }
+      return false
+    }),
+  )
 
-  return !!result;
+  return !!result
 }
 
 export function Sidebar(props: {
@@ -152,7 +154,7 @@ function SidebarItem(props: {
     (event: KeyboardEvent | MouseEvent) => {
       if ('key' in event && event.key !== 'Enter') return
       if (item.link) return
-      setCollapsed((x) => !x)    
+      setCollapsed((x) => !x)
     },
     [item.link],
   )
@@ -217,16 +219,22 @@ function SidebarItem(props: {
                   {item.text}
                 </RouterLink>
               ) : (
-                <div className={clsx(depth === 0 ? (item.items && checkSectionTitleActive(item.items, pathname) ? styles.sectionTitleActive : styles.sectionTitle) : styles.item)}>
+                <div
+                  className={clsx(
+                    depth === 0
+                      ? item.items && checkSectionTitleActive(item.items, pathname)
+                        ? styles.sectionTitleActive
+                        : styles.sectionTitle
+                      : styles.item,
+                  )}
+                >
                   {item.items && !checkSectionTitleActive(item.items, pathname) && collapsed ? (
-                    <RouterLink
-                      data-active={false}
-                      onClick={onClick}
-                      to={item.items[0].link!}
-                    >
+                    <RouterLink data-active={false} onClick={onClick} to={item.items[0].link!}>
                       {item.text}
                     </RouterLink>
-                  ) : item.text}
+                  ) : (
+                    item.text
+                  )}
                 </div>
               ))}
 

--- a/src/app/hooks/useSidebar.ts
+++ b/src/app/hooks/useSidebar.ts
@@ -19,7 +19,7 @@ export function useSidebar(): UseSidebarReturnType {
     return keys[keys.length - 1]
   }, [sidebar, pathname])
   if (!sidebarKey) return { items: [] }
-
+  
   if (Array.isArray(sidebar[sidebarKey]))
     return { key: sidebarKey, items: sidebar[sidebarKey] } as UseSidebarReturnType
   return { ...sidebar[sidebarKey], key: sidebarKey } as UseSidebarReturnType

--- a/src/app/hooks/useSidebar.ts
+++ b/src/app/hooks/useSidebar.ts
@@ -19,7 +19,7 @@ export function useSidebar(): UseSidebarReturnType {
     return keys[keys.length - 1]
   }, [sidebar, pathname])
   if (!sidebarKey) return { items: [] }
-  
+
   if (Array.isArray(sidebar[sidebarKey]))
     return { key: sidebarKey, items: sidebar[sidebarKey] } as UseSidebarReturnType
   return { ...sidebar[sidebarKey], key: sidebarKey } as UseSidebarReturnType


### PR DESCRIPTION
Improve sidebar navigation: Collapsible nav titles now redirect to their first sub-nav option and highlight when selected.

## Images:
![image](https://github.com/RichardIrala/vocs/assets/93644394/a3ad803e-06fe-47b9-894e-b1cca05e9758)

![image](https://github.com/RichardIrala/vocs/assets/93644394/ca6ae6e7-b345-44ef-8633-9f75e8848b94)
